### PR TITLE
Set navigation bar to black

### DIFF
--- a/app/src/main/java/com/dozingcatsoftware/bouncy/AboutActivity.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/AboutActivity.java
@@ -3,6 +3,8 @@ package com.dozingcatsoftware.bouncy;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.Window;
@@ -14,6 +16,10 @@ public class AboutActivity extends Activity {
         super.onCreate(savedInstanceState);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.about);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            this.getWindow().setNavigationBarColor(Color.BLACK);
+        }
 
         // Get text to display by replacing "[TABLE_RULES]" with the contents of string resource
         // with ID table[level]_rules.

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
@@ -157,7 +157,9 @@ public class BouncyActivity extends Activity {
         (new Thread(VPSoundpool::loadSounds)).start();
         VPSoundpool.hapticFn = () -> {
             if (supportsHapticFeedback && useHapticFeedback) {
-                scoreView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
+                scoreView.performHapticFeedback(
+                        HapticFeedbackConstants.KEYBOARD_TAP,
+                        HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING);
             }
         };
         this.setVolumeControlStream(AudioManager.STREAM_MUSIC);

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
@@ -17,6 +17,7 @@ import com.dozingcatsoftware.vectorpinball.model.GameState;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.media.AudioManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -93,6 +94,10 @@ public class BouncyActivity extends Activity {
 
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.main);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            this.getWindow().setNavigationBarColor(Color.BLACK);
+        }
 
         this.numberOfLevels = FieldLayoutReader.getNumberOfLevels(this);
         this.currentLevel = getInitialLevel();

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyPreferences.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyPreferences.java
@@ -1,5 +1,6 @@
 package com.dozingcatsoftware.bouncy;
 
+import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
@@ -9,6 +10,10 @@ public class BouncyPreferences extends PreferenceActivity {
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.preferences);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            this.getWindow().setNavigationBarColor(Color.BLACK);
+        }
 
         // If multitouch or haptic feedback APIs aren't available, disable the preference items.
         // Coincidentally, both require Froyo (API level 8).

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.VPTheme" parent="android:Theme.Material.NoActionBar.Fullscreen" />
+    <style name="Theme.VPTheme" parent="android:Theme.Material.NoActionBar.Fullscreen">
+        <!--
+        On some devices setting solid black has no effect but nearly black works:
+        https://stackoverflow.com/questions/51187710/android-navigationbarcolor-doesnt-change-to-black-only-to-black
+        -->
+        <item name="android:navigationBarColor">#010101</item>
+    </style>
 </resources>


### PR DESCRIPTION
Needed for some devices that default to a light navigation bar. Also use `HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING` in haptic feedback. 