### PR TITLE
Exit from help and preferences activities back to main game by pressing "P"

### DIFF
--- a/app/src/main/java/com/dozingcatsoftware/bouncy/AboutActivity.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/AboutActivity.java
@@ -7,6 +7,7 @@ import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
+import android.view.KeyEvent;
 import android.view.Window;
 import android.widget.TextView;
 
@@ -42,6 +43,16 @@ public class AboutActivity extends Activity {
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         int padding = Math.min(metrics.widthPixels, metrics.heightPixels) / 25;
         tv.setPadding(padding, padding, padding, padding);
+    }
+
+    @Override public boolean onKeyDown(int keyCode, KeyEvent event) {
+        // Return to main activity when "P" is pressed, to avoid accidentally quitting by hitting
+        // "back" multiple times. See https://github.com/dozingcat/Vector-Pinball/issues/103.
+        if (keyCode == KeyEvent.KEYCODE_P) {
+            finish();
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
     }
 
     public static Intent startForLevel(Context context, int level) {

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyPreferences.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyPreferences.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.os.Vibrator;
 import android.preference.CheckBoxPreference;
 import android.preference.PreferenceActivity;
+import android.view.KeyEvent;
 
 public class BouncyPreferences extends PreferenceActivity {
 
@@ -46,5 +47,15 @@ public class BouncyPreferences extends PreferenceActivity {
             hapticPref.setChecked(false);
             hapticPref.setEnabled(false);
         }
+    }
+
+    @Override public boolean onKeyDown(int keyCode, KeyEvent event) {
+        // Return to main activity when "P" is pressed, to avoid accidentally quitting by hitting
+        // "back" multiple times. See https://github.com/dozingcat/Vector-Pinball/issues/103.
+        if (keyCode == KeyEvent.KEYCODE_P) {
+            finish();
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
     }
 }


### PR DESCRIPTION
For #103. It can be useful to have a way to return to the main game that won't quit on multiple presses. Also at least in the emulator the escape key doesn't work to go back, so this allows full navigation with the keyboard.