### PR TITLE
Fix bad OpenGL call ordering that could cause crashes on some devices

### DIFF
--- a/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
@@ -443,7 +443,7 @@ public class BouncyActivity extends Activity {
             fieldViewManager.setCustomLineWidth(lineWidth);
         }
 
-        boolean useOpenGL = prefs.getBoolean("useOpenGL", false);
+        boolean useOpenGL = prefs.getBoolean("useOpenGL", true);
         if (useOpenGL) {
             if (glFieldView.getVisibility() != View.VISIBLE) {
                 canvasFieldView.setVisibility(View.GONE);

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/GL20Renderer.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/GL20Renderer.java
@@ -57,8 +57,10 @@ public class GL20Renderer implements IFieldRenderer.FloatOnlyRenderer, GLSurface
         this.glView = view;
         view.getHolder().setFormat(PixelFormat.RGBA_8888);
         view.getHolder().setFormat(PixelFormat.TRANSPARENT);
-        view.setEGLConfigChooser(8,8,8,8,16,0);
+        // This order matters at least on some devices: setEGLContextClientVersion must be called
+        // before setEGLConfigChooser. See https://stackoverflow.com/questions/26504742/open-gl-bad-config-error-on-samsung-s4
         view.setEGLContextClientVersion(2);
+        view.setEGLConfigChooser(8,8,8,8,16,0);
         view.setRenderer(this);
         view.setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
         this.shaderLookupFn = shaderLookupFn;


### PR DESCRIPTION
Also default to using OpenGL if there are no preferences set. That was the intention with #52 but that only changed the default value on the preferences screen, so the app wouldn't be using OpenGL until you went to the preferences screen and returned.