### PR TITLE
Fix bug where OpenGL renderers always draw circles over lines

### DIFF
--- a/app/src/main/java/com/dozingcatsoftware/bouncy/GL10Renderer.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/GL10Renderer.java
@@ -16,7 +16,6 @@ import javax.microedition.khronos.opengles.GL10;
 public class GL10Renderer implements IFieldRenderer.FloatOnlyRenderer, GLSurfaceView.Renderer {
     private final GLFieldView glView;
     private GLVertexListManager vertexListManager = new GLVertexListManager();
-    private GLVertexList lineVertexList;
 
     private FieldViewManager manager;
 
@@ -37,7 +36,6 @@ public class GL10Renderer implements IFieldRenderer.FloatOnlyRenderer, GLSurface
 
     void startGLElements(GL10 gl) {
         vertexListManager.begin();
-        lineVertexList = vertexListManager.addVertexListForMode(GL10.GL_LINES);
     }
 
     void endGLElements(GL10 gl) {
@@ -62,6 +60,11 @@ public class GL10Renderer implements IFieldRenderer.FloatOnlyRenderer, GLSurface
     // Implementation of IFieldRenderer drawing methods that FieldElement classes can call.
     // Assumes cacheScaleAndOffsets has been called.
     @Override public void drawLine(float x1, float y1, float x2, float y2, int color) {
+        // Continue with "current" line vertex list if possible.
+        GLVertexList lastList = vertexListManager.mostRecentVertexList();
+        GLVertexList lineVertexList = (lastList != null && lastList.getGlMode() == GL10.GL_LINES)
+                ? lastList
+                : vertexListManager.addVertexListForMode(GL10.GL_LINES);
         lineVertexList.addVertex(manager.world2pixelX(x1), manager.world2pixelY(y1));
         lineVertexList.addVertex(manager.world2pixelX(x2), manager.world2pixelY(y2));
         addColorToVertexList(lineVertexList, color);

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/GL20Renderer.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/GL20Renderer.java
@@ -286,7 +286,6 @@ public class GL20Renderer implements IFieldRenderer.FloatOnlyRenderer, GLSurface
         prepareBuffers();
         for (int i = 0; i < numShapeBatches; i++) {
             ShapeBatch b = shapeBatches[i];
-            // android.util.Log.i("GL", "*** i=" + i + ", batch shape:" + b.shape + ", startIndex: " + b.startIndex + ", endIndex:" + b.endIndex);
             switch (b.shape) {
                 case LINE:
                     drawLines(b.startIndex, b.count);

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/util/GLVertexList.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/util/GLVertexList.java
@@ -20,6 +20,9 @@ public class GLVertexList {
 
     int glMode;
 
+    public int getGlMode() {
+        return this.glMode;
+    }
     public void setGLMode(int glMode) {
         this.glMode = glMode;
     }

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/util/GLVertexListManager.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/util/GLVertexListManager.java
@@ -45,4 +45,11 @@ public class GLVertexListManager {
         vertexListCount++;
         return vl;
     }
+
+    public GLVertexList mostRecentVertexList() {
+        if (vertexListCount == 0) {
+            return null;
+        }
+        return vertexLists[vertexListCount - 1];
+    }
 }

--- a/app/src/main/java/com/dozingcatsoftware/vectorpinball/elements/RolloverGroupElement.java
+++ b/app/src/main/java/com/dozingcatsoftware/vectorpinball/elements/RolloverGroupElement.java
@@ -294,19 +294,24 @@ public class RolloverGroupElement extends FieldElement {
         // default color defined at the group level
         int groupColor = currentColor(DEFAULT_COLOR);
 
-        // for each rollover, draw outlined circle for inactive or filled circle for active
-        int rsize = this.rollovers.size();
-        for (int i = 0; i < rsize; i++) {
+        // For each rollover, draw outlined circle for inactive or filled circle for active.
+        // As a probably-useless optimization, draw outlines before filled circles, to reduce
+        // the number of switches the OpenGL renderer has to make between circle and line programs.
+        int numRollovers = this.rollovers.size();
+        for (int i = 0; i < numRollovers; i++) {
             Rollover r = this.rollovers.get(i);
-            // use custom rollover color if available
-            int color = (r.color != null) ? r.color : groupColor;
-
-            if (activeRollovers.contains(r)) {
-                renderer.fillCircle(r.position.x, r.position.y, r.radius, color);
-            }
-            else {
+            if (!this.activeRollovers.contains(r)) {
+                // use custom rollover color if available
+                int color = (r.color != null) ? r.color : groupColor;
                 renderer.frameCircle(r.position.x, r.position.y, r.radius, color);
             }
+        }
+
+        int numActive = this.activeRollovers.size();
+        for (int i = 0; i < numActive; i++) {
+            Rollover r = this.activeRollovers.get(i);
+            int color = (r.color != null) ? r.color : groupColor;
+            renderer.fillCircle(r.position.x, r.position.y, r.radius, color);
         }
     }
 }


### PR DESCRIPTION
The OpenGL renderers were always drawing all lines and then all (filled) circles regardless of the order in which the render functions were called. This adds "batches" of lines and circles that preserve the correct order, while minimizing OpenGL draw commands.

Fixes https://github.com/dozingcat/Vector-Pinball/issues/165