### PR TITLE
Now can see the tables when browsing them

### DIFF
--- a/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
@@ -625,6 +625,8 @@ public class BouncyActivity extends Activity {
             // synchronized because that can deadlock the FieldDriver thread.
             // All of this concurrency is badly in need of refactoring.
             synchronized (field) {
+                restoreMenuHeight();
+
                 buttonPanel.setVisibility(View.GONE);
                 highScorePanel.setVisibility(View.GONE);
                 resetFieldForCurrentLevel();
@@ -674,6 +676,8 @@ public class BouncyActivity extends Activity {
     }
 
     void switchToTable(int tableNum) {
+        shrinkMenuToTableSelectionSize();
+
         this.currentLevel = tableNum;
         synchronized (field) {
             resetFieldForCurrentLevel();
@@ -688,6 +692,28 @@ public class BouncyActivity extends Activity {
 
     public void doSwitchTable(View view) {
         doNextTable(view);
+    }
+
+
+    private int menuHeight;
+    private int tableSelectionHeight;
+
+    private void shrinkMenuToTableSelectionSize() {
+        // There must be a better place to obtain this information
+        if (menuHeight == 0) {
+            menuHeight = buttonPanel.getHeight();
+            tableSelectionHeight = previousTableButton.getHeight();
+        }
+
+        buttonPanel.getLayoutParams().height = tableSelectionHeight;
+        buttonPanel.setLayoutParams(buttonPanel.getLayoutParams());
+    }
+
+    private void restoreMenuHeight() {
+        if (menuHeight != 0) {
+            buttonPanel.getLayoutParams().height = menuHeight;
+            buttonPanel.setLayoutParams(buttonPanel.getLayoutParams());
+        }
     }
 
     public void doNextTable(View view) {


### PR DESCRIPTION
The menu obscured the screen when browsing through tables -- it was hard to see them:
So the menu now gets a lot smaller when navigating tables:

| Before | After |
|--------|--------|
| ![before](https://github.com/dozingcat/Vector-Pinball/assets/398113/66a176e1-e994-48c4-a38a-37a9f3d44066) | ![after](https://github.com/dozingcat/Vector-Pinball/assets/398113/ef1068af-b0cc-4329-880a-2b833eee2f15) |


Apologies for the slightly ugly implementation -- I'm no Android programmer :-(