### PR TITLE
R1 L1 for flippers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId "com.dozingcatsoftware.bouncy"
-        minSdkVersion 4
+        minSdkVersion 9
         targetSdkVersion 34
         versionCode 38
         versionName "1.13.0"

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
@@ -1,5 +1,8 @@
 package com.dozingcatsoftware.bouncy;
 
+import static com.dozingcatsoftware.bouncy.FieldViewManager.LEFT_FLIPPER_KEYS;
+import static com.dozingcatsoftware.bouncy.FieldViewManager.RIGHT_FLIPPER_KEYS;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -318,12 +321,12 @@ public class BouncyActivity extends Activity {
         }
         // When showing the main menu, switch tables with the flipper buttons.
         if (!field.getGameState().isGameInProgress() && buttonPanel.getVisibility() == View.VISIBLE) {
-            if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
+            if (LEFT_FLIPPER_KEYS.contains(keyCode)) {
                 doPreviousTable(null);
                 startGameButton.requestFocus();
                 return true;
             }
-            if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+            if (RIGHT_FLIPPER_KEYS.contains(keyCode)) {
                 doNextTable(null);
                 startGameButton.requestFocus();
                 return true;

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/BouncyActivity.java
@@ -1,5 +1,6 @@
 package com.dozingcatsoftware.bouncy;
 
+import static android.view.KeyEvent.KEYCODE_BUTTON_A;
 import static com.dozingcatsoftware.bouncy.FieldViewManager.LEFT_FLIPPER_KEYS;
 import static com.dozingcatsoftware.bouncy.FieldViewManager.RIGHT_FLIPPER_KEYS;
 
@@ -329,6 +330,10 @@ public class BouncyActivity extends Activity {
             if (RIGHT_FLIPPER_KEYS.contains(keyCode)) {
                 doNextTable(null);
                 startGameButton.requestFocus();
+                return true;
+            }
+            if (keyCode == KEYCODE_BUTTON_A) {
+                doStartGame(null);
                 return true;
             }
         }

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/FieldViewManager.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/FieldViewManager.java
@@ -332,7 +332,7 @@ public class FieldViewManager {
     static List<Integer> LEFT_FLIPPER_KEYS = Arrays.asList(
             KeyEvent.KEYCODE_Z, KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.KEYCODE_BUTTON_L1);
     static List<Integer> RIGHT_FLIPPER_KEYS = Arrays.asList(
-            KeyEvent.KEYCODE_SLASH, KeyEvent.KEYCODE_DPAD_RIGHT, KeyEvent.KEYCODE_BUTTON_L1);
+            KeyEvent.KEYCODE_SLASH, KeyEvent.KEYCODE_DPAD_RIGHT, KeyEvent.KEYCODE_BUTTON_R1);
     static List<Integer> ALL_FLIPPER_KEYS = Arrays.asList(
             KeyEvent.KEYCODE_SPACE, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER);
 

--- a/app/src/main/java/com/dozingcatsoftware/bouncy/FieldViewManager.java
+++ b/app/src/main/java/com/dozingcatsoftware/bouncy/FieldViewManager.java
@@ -330,9 +330,9 @@ public class FieldViewManager {
     }
 
     static List<Integer> LEFT_FLIPPER_KEYS = Arrays.asList(
-            KeyEvent.KEYCODE_Z, KeyEvent.KEYCODE_DPAD_LEFT);
+            KeyEvent.KEYCODE_Z, KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.KEYCODE_BUTTON_L1);
     static List<Integer> RIGHT_FLIPPER_KEYS = Arrays.asList(
-            KeyEvent.KEYCODE_SLASH, KeyEvent.KEYCODE_DPAD_RIGHT);
+            KeyEvent.KEYCODE_SLASH, KeyEvent.KEYCODE_DPAD_RIGHT, KeyEvent.KEYCODE_BUTTON_L1);
     static List<Integer> ALL_FLIPPER_KEYS = Arrays.asList(
             KeyEvent.KEYCODE_SPACE, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER);
 


### PR DESCRIPTION
I wanted to be able to use a game controller (eg: Playstation 4) with the left and right bumpers to control the flippers. Now I can.

Note:
- Bumping minSdkVersion to 9 was required to access `KeyEvent.KEYCODE_BUTTON_L1`. This means the app won't run on anything older than Gingerbread devices from about 2010. If that's a problem the keycodes could be replaced with their numeric literals.
- The code that uses `KEYCODE_BUTTON_A` to start the game is not strictly required by the commit. It's actually a byproduct of removing the "START BUTTON" menu item in #179